### PR TITLE
update gpg cli args for gpg2.x

### DIFF
--- a/new-release-scripts/jenkins/source-jenkins-credentials.sh
+++ b/new-release-scripts/jenkins/source-jenkins-credentials.sh
@@ -28,7 +28,7 @@ chmod 700 $TMP_RSA_KEY_NAME
 echo "$JENKINS_GPG_KEY" | tr "," "\n" > $TMP_GPG_KEY_NAME
 chmod 700 $TMP_GPG_KEY_NAME
 export GNUPGHOME=$tmpdir
-gpg --allow-secret-key-import --import $TMP_GPG_KEY_NAME
+gpg --allow-secret-key-import --batch --import $TMP_GPG_KEY_NAME
 popd
 
 # Set-up env vars needed by Spark release scripts


### PR DESCRIPTION
moving maven publishing builds to ubuntu 18 LTS, gpg2 needs an additional CLI arg.

tested here via sed in the maven publish snapshot test build:

`sed -i 's/-key-import/-key-import --batch/' spark-utils/new-release-scripts/jenkins/source-jenkins-credentials.sh`

https://amplab.cs.berkeley.edu/jenkins/job/spark-master-maven-snapshots-ubuntu-testing/3/console
https://amplab.cs.berkeley.edu/jenkins/job/spark-master-maven-snapshots-ubuntu-testing/configure